### PR TITLE
Allow example script to run without installing package

### DIFF
--- a/examples/bartlett_lewis_demo.py
+++ b/examples/bartlett_lewis_demo.py
@@ -1,3 +1,19 @@
+"""Demonstration script for the Bartlett-Lewis rainfall model.
+
+This script can be executed directly from the repository root without first
+installing the ``lildrip`` package.  To achieve this we append the ``src``
+directory to ``sys.path`` so the package can be imported when running
+
+``python examples/bartlett_lewis_demo.py``.
+"""
+
+from pathlib import Path
+import sys
+
+# Allow importing ``lildrip`` when the package has not been installed.  This
+# keeps the example easy to run for new contributors.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
 import pandas as pd
 from lildrip import BartlettLewisModel, plot_comparison_bars
 


### PR DESCRIPTION
## Summary
- make Bartlett-Lewis demo example runnable by adding `src` to `sys.path`
- document in-script that example can run from repo root

## Testing
- `MPLBACKEND=Agg python examples/bartlett_lewis_demo.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e9fe8f48483229d0b07fcb1819e98