### PR TITLE
Separar endpoints e preparar deploy no GCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,18 @@ python examples/bartlett_lewis_demo.py
 O script salva os resultados em arquivos CSV (chuva sintética, parâmetros
 calibrados e chuva desagregada) e exibe um gráfico comparando os valores
 originais e desagregados.
+
+## Deploy no Google Cloud Functions
+
+O arquivo `main.py` expõe dois endpoints FastAPI (`/calibrar` e `/desagregar`)
+e pode ser publicado como uma Cloud Function (2ª geração). Após configurar o
+`gcloud`, execute:
+
+```bash
+gcloud functions deploy lildrip-api \
+  --gen2 --runtime=python312 --region=us-central1 \
+  --entry-point=app --trigger-http --allow-unauthenticated
+```
+
+O parâmetro `--entry-point=app` aponta para o objeto FastAPI definido em
+`main.py`.

--- a/main.py
+++ b/main.py
@@ -1,55 +1,77 @@
 from fastapi import FastAPI, UploadFile, File, Form
 from fastapi.responses import StreamingResponse
 import pandas as pd
+import json
 from io import BytesIO
+
 from lildrip import BartlettLewisModel
+
 
 app = FastAPI()
 
-@app.post("/calibrar-e-desagregar")
-def calibrar_e_desagregar(
+
+@app.post("/calibrar")
+async def calibrar(
     arquivo: UploadFile = File(...),
     interval_minutes: int = Form(10),
     inter_event_gap_minutes: int = Form(30),
     intra_event_gap_minutes: int = Form(15),
-    disagg_interval_minutes: int = Form(10),
 ):
-    # Lê CSV do usuário
-    df = pd.read_csv(arquivo.file, parse_dates=['timestamp'])
-    df = df.set_index('timestamp')
+    """Calibrate model parameters from a high-resolution rainfall series.
+
+    The uploaded CSV must contain ``timestamp`` and ``rainfall_mm`` columns.
+    The endpoint returns the calibrated parameters in JSON format.
+    """
+    df = pd.read_csv(arquivo.file, parse_dates=["timestamp"]).set_index("timestamp")
 
     model = BartlettLewisModel()
+    events = model.identify_events(
+        df["rainfall_mm"], inter_event_gap_minutes=inter_event_gap_minutes
+    )
 
-    # Pré-processamento e identificação de eventos
-    df_proc = model.load_and_preprocess_data(
-        file_path=None,  # a função original precisa de ajuste para aceitar DataFrame
-        time_column='timestamp',
-        rainfall_column='rainfall_mm',
-        interval_minutes=interval_minutes
-    ) if False else df  # bypass da função para este exemplo
-
-    events = model.identify_events(df['rainfall_mm'], inter_event_gap_minutes=inter_event_gap_minutes)
-
-    # Calibração
-    model.calibrate(
+    params = model.calibrate(
         events,
         interval_minutes=interval_minutes,
         default_beta=None,
         default_eta=None,
-        intra_event_gap_minutes=intra_event_gap_minutes
+        intra_event_gap_minutes=intra_event_gap_minutes,
     )
 
-    # Criar série grossa (exemplo: agregando por hora)
-    coarse_series = df['rainfall_mm'].resample(f'{disagg_interval_minutes*2}min').sum()
+    return params
 
-    # Desagregação
-    disagg = model.disaggregate(coarse_series, fine_interval_minutes=disagg_interval_minutes)
 
-    # Converter para CSV e retornar
+@app.post("/desagregar")
+async def desagregar(
+    arquivo: UploadFile = File(...),
+    params: str = Form(...),
+    disagg_interval_minutes: int = Form(10),
+):
+    """Disaggregate a coarse rainfall series using previously calibrated parameters.
+
+    ``params`` must be a JSON string with the calibration parameters obtained
+    from ``/calibrar``. The uploaded CSV must contain ``timestamp`` and
+    ``rainfall_mm`` columns representing the coarse series to be disaggregated.
+    The endpoint returns a CSV file with the disaggregated rainfall series.
+    """
+    df = pd.read_csv(arquivo.file, parse_dates=["timestamp"]).set_index("timestamp")
+    params_dict = json.loads(params)
+
+    model = BartlettLewisModel(params=params_dict)
+    coarse_series = df["rainfall_mm"]
+    disagg = model.disaggregate(
+        coarse_series, fine_interval_minutes=disagg_interval_minutes
+    )
+
     buffer = BytesIO()
-    disagg.to_frame(name='rainfall_mm').to_csv(buffer)
+    disagg.to_frame(name="rainfall_mm").to_csv(buffer)
     buffer.seek(0)
 
-    return StreamingResponse(buffer, media_type="text/csv", headers={
-        "Content-Disposition": "attachment; filename=chuva_desagregada.csv"
-    })
+    return StreamingResponse(
+        buffer,
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=chuva_desagregada.csv"},
+    )
+
+
+# The ``app`` object is the ASGI entry point for Google Cloud Functions (2nd gen).
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pyyaml==6.0.2
 pytest==8.3.2
 fastapi
 uvicorn
-pyyaml
+functions-framework==3.5.0


### PR DESCRIPTION
## Summary
- Criação de dois endpoints FastAPI distintos: `/calibrar` retorna parâmetros do modelo, enquanto `/desagregar` usa parâmetros fornecidos para gerar a série desagregada.
- Adicionado `functions-framework` às dependências e instruções no README para deploy como Cloud Function.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eae406d048322afe23d5ffeb2a5d9